### PR TITLE
Fix uninitialized log component

### DIFF
--- a/rxplus/ws.py
+++ b/rxplus/ws.py
@@ -110,9 +110,8 @@ class RxWSServer(Subject):
         # setup the log source
         if logcomp is None:
             logcomp = EmptyLogComp()
-        else:
-            self.logcomp = logcomp
 
+        self.logcomp = logcomp
         self.logcomp.set_super(super())
 
         # Store connected clients
@@ -322,9 +321,8 @@ class RxWSClient(Subject):
         # setup the log source
         if logcomp is None:
             logcomp = EmptyLogComp()
-        else:
-            self.logcomp = logcomp
 
+        self.logcomp = logcomp
         self.logcomp.set_super(super())
         
 


### PR DESCRIPTION
## Summary
- ensure `self.logcomp` is initialized for both websocket server and client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869fa597c24832d835cf590b767a699