### PR TITLE
Add unit tests for reactive utilities

### DIFF
--- a/tests/test_duplex.py
+++ b/tests/test_duplex.py
@@ -1,0 +1,31 @@
+import reactivex as rx
+from reactivex.subject import Subject
+
+from rxplus.duplex import make_duplex, connect_adapter
+
+
+def test_make_duplex_defaults():
+    d = make_duplex()
+    assert isinstance(d.sink, Subject)
+    assert isinstance(d.stream, Subject)
+
+
+def test_connect_adapter_propagates():
+    a = make_duplex()
+    b = make_duplex()
+
+    received_a = []
+    received_b = []
+
+    a.sink.subscribe(received_a.append)
+    b.sink.subscribe(received_b.append)
+
+    cd = connect_adapter(a, b)
+
+    a.stream.on_next('first')
+    b.stream.on_next('second')
+
+    assert received_b == ['first']
+    assert received_a == ['second']
+
+    cd.dispose()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,49 @@
+import reactivex as rx
+
+from rxplus.logging import LogItem, log_filter, drop_log, log_redirect_to
+
+
+class Collector:
+    def __init__(self):
+        self.items = []
+
+    def on_next(self, value):
+        self.items.append(value)
+
+    def on_error(self, error):
+        raise error
+
+    def on_completed(self):
+        pass
+
+
+def test_log_filter():
+    logs = [LogItem('a', 'INFO'), LogItem('b', 'DEBUG'), 'x']
+    collected = []
+    rx.from_(logs).pipe(log_filter({'DEBUG'})).subscribe(collected.append)
+
+    assert len(collected) == 1
+    log = collected[0]
+    assert isinstance(log, LogItem)
+    assert log.level == 'DEBUG'
+    assert log.msg == 'b'
+
+
+def test_drop_log():
+    items = [LogItem('a'), 'keep']
+    collected = []
+    rx.from_(items).pipe(drop_log()).subscribe(collected.append)
+
+    assert collected == ['keep']
+
+
+def test_log_redirect_to():
+    target = Collector()
+    output = []
+    source = [LogItem('x', 'INFO'), LogItem('y', 'DEBUG'), 1]
+    rx.from_(source).pipe(log_redirect_to(target, {'INFO'})).subscribe(output.append)
+
+    assert output == [1]
+    assert len(target.items) == 1
+    assert isinstance(target.items[0], LogItem)
+    assert target.items[0].msg == 'x'

--- a/tests/test_opt.py
+++ b/tests/test_opt.py
@@ -1,0 +1,43 @@
+import io
+from contextlib import redirect_stdout
+
+import reactivex as rx
+from reactivex.subject import Subject
+
+from rxplus.opt import stream_print_out, redirect_to
+
+
+class Collector:
+    def __init__(self):
+        self.items = []
+
+    def on_next(self, value):
+        self.items.append(value)
+
+    def on_error(self, error):
+        raise error
+
+    def on_completed(self):
+        pass
+
+
+def test_stream_print_out(capsys):
+    out = io.StringIO()
+    items = []
+    with redirect_stdout(out):
+        rx.from_([1, 2]).pipe(stream_print_out('> ')).subscribe(items.append)
+    stdout = out.getvalue()
+    assert items == [1, 2]
+    assert '>1' in stdout.replace(' ', '')
+    assert '>2' in stdout.replace(' ', '')
+
+
+def test_redirect_to():
+    target = Collector()
+    received = []
+    rx.from_([1, 2, 3, 4]).pipe(
+        redirect_to(lambda x: x % 2 == 0, target)
+    ).subscribe(received.append)
+
+    assert received == [1, 3]
+    assert target.items == [2, 4]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import pytest
+
+from rxplus.utils import TaggedData, get_short_error_info, get_full_error_info
+
+
+def test_tagged_data_repr_str():
+    td = TaggedData('tag', 123)
+    assert str(td) == '(tag=tag, 123)'
+    assert repr(td) == '(tag=tag, 123)'
+
+
+def test_error_info_functions():
+    try:
+        raise ValueError('oops')
+    except Exception as e:
+        short = get_short_error_info(e)
+        full = get_full_error_info(e)
+
+    assert 'ValueError' in short and 'oops' in short
+    assert 'ValueError' in full and 'oops' in full

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -26,3 +26,5 @@ def test_wsstr_and_wsbytes():
         b.package_type_check("x")
     with pytest.raises(TypeError):
         b.unpackage("x")
+
+# TODO: more sophisticated tests for WSServer and WSClient are needed here.

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -1,0 +1,13 @@
+import pytest
+
+from rxplus.ws import wsdt_factory, WSStr, WSBytes
+
+
+def test_wsdt_factory_valid():
+    assert isinstance(wsdt_factory('string'), WSStr)
+    assert isinstance(wsdt_factory('byte'), WSBytes)
+
+
+def test_wsdt_factory_invalid():
+    with pytest.raises(ValueError):
+        wsdt_factory('unknown')

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -1,13 +1,28 @@
 import pytest
 
-from rxplus.ws import wsdt_factory, WSStr, WSBytes
+from rxplus.ws import WSBytes, WSStr, wsdt_factory
 
 
 def test_wsdt_factory_valid():
-    assert isinstance(wsdt_factory('string'), WSStr)
-    assert isinstance(wsdt_factory('byte'), WSBytes)
+    assert isinstance(wsdt_factory("string"), WSStr)
+    assert isinstance(wsdt_factory("byte"), WSBytes)
 
 
 def test_wsdt_factory_invalid():
     with pytest.raises(ValueError):
-        wsdt_factory('unknown')
+        wsdt_factory("unknown")
+
+
+def test_wsstr_and_wsbytes():
+    s = WSStr()
+    assert s.package(123) == "123"
+    assert s.unpackage("abc") == "abc"
+
+    b = WSBytes()
+    data = b"abc"
+    assert b.package(data) == data
+    assert b.unpackage(data) == data
+    with pytest.raises(TypeError):
+        b.package_type_check("x")
+    with pytest.raises(TypeError):
+        b.unpackage("x")


### PR DESCRIPTION
## Summary
- add tests for utils error handling and TaggedData
- add tests for duplex connection helpers
- add tests for custom operators and logging helpers
- add tests for WebSocket datatype factory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687277d1eb78832daefececc3f968efd