### PR TITLE
fix(ci): remove unused type: ignore in ws/server.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,26 +1,44 @@
-# rxplus
+# Repository Guidelines
 
-`rxplus` is a Python library that provides a collection of extensions for the `reactivex` library.
+- Repo: https://github.com/LucianoXu/rxplus.git
+- GitHub issues/comments/PR comments: use literal multiline strings or `-F - <<'EOF'` (or $'...') for real newlines; never embed "\\n".
 
-## Build & Development
 
-- Python: 3.13
-- Environment: `conda activate rxplus`
-- Pre-commit hooks: `pre-commit install`
-- Test: `pytest --cov=rxplus --cov-report=term-missing`
-- Lint: `ruff check .`
-- Format: `ruff format .`
-- Type check: `mypy rxplus`
+## Project Structure & Module Organization
+- Source code: `rxplus/`.
+- Docs: `docs/`.
+- Tasks that can be started by `python -m ...` are in `tasks/`.
+- Tests: `tests/`.
+- Information for Agents: `ai-instru/`. It includes Agent skills, remote server information, Grafana stacks and running projects info.
 
-## Coding Style
 
-- Formatting/linting: ruff + mypy
-- Avoid `Any` types; use explicit type annotations
-- Keep files under ~700 LOC; split when it improves clarity
-- Add brief comments for non-obvious logic
+## Build, Test, and Development Commands
+- Pre-commit hooks: `prek install` (runs same checks as CI)
+- Test with coverage: `pytest --cov=rxplus --cov-report=term-missing`
 
-## Commit Guidelines
 
-- Write concise, descriptive commit messages
-- Run `pre-commit` before committing
-- Keep PRs focused on a single concern
+## Coding Style & Naming Conventions
+- Formatting/linting using `mypy`: `conda run -n turbo mypy`.
+- Avoid ambiguous typing (e.g., `Any`) whenever possible. Don't abuse `# type: ignore`. Try to build clear and informative typing notations.
+- Follow the reactive programming paradigm.
+- Aim to keep files under ~700 LOC; guideline only (not a hard guardrail). Split/refactor when it improves clarity or testability.
+- Add brief code comments for tricky or non-obvious logic.
+- **Logging**: Use OpenTelemetry via `rxplus/telemetry.py` (`OTelLogger`), never `print` or `logging` directly. Refer to `ai-instru` for the Grafana endpoint of dhproto.
+- **Documentation**: After implementing any new component or instance, add a doc in `docs/` covering: introduction, arguments, reactive components, dataflow graph, sink/stream data types, log records, potential vulnerabilities.
+
+
+## Commit & Pull Request Guidelines
+- You should also include the design proposal/specification files in the commit.
+- After pushing the commit, you should use `gh` to watch the CI result and make sure it passes.
+- When required to use `PR` mode, or the development work is heavy, you should work in a `git` worktree in a separated branch, and contribute to the code by making pull requests.
+
+## Agent-Specific Notes
+- When adding a new `AGENTS.md` anywhere in the repo, also add a `CLAUDE.md` symlink pointing to it (example: `ln -s AGENTS.md CLAUDE.md`).
+- When working on a GitHub Issue or PR, print the full URL at the end of the task.
+- When answering questions, respond with high-confidence answers only: verify in code; do not guess.
+- Lint/format churn:
+  - If staged+unstaged diffs are formatting-only, auto-resolve without asking.
+  - If commit/push already requested, auto-stage and include formatting-only follow-ups in the same commit (or a tiny follow-up commit if needed), no extra confirmation.
+  - Only ask when changes are semantic (logic/data/behavior).
+- **NEVER** change `devlop.md`. This is for human notes.
+- **NEVER** commit any real ip-address, api-keys or other security related information. Use obviously fake placeholders in the documentations.

--- a/rxplus/ws/server.py
+++ b/rxplus/ws/server.py
@@ -377,7 +377,7 @@ class RxWSServer(Subject, OTelLoggingMixin):
                 ping_interval=self.ping_interval,
                 ping_timeout=self.ping_timeout,
                 max_size=None,
-                process_request=self._process_request,  # type: ignore[arg-type]
+                process_request=self._process_request,
             )
             if dual_sock is not None:
                 serve_kwargs["sock"] = dual_sock


### PR DESCRIPTION
## Summary
- Remove unused `# type: ignore[arg-type]` on `process_request` dict entry in `rxplus/ws/server.py:380`, which was causing CI mypy failure
- Update `AGENTS.md` with project conventions

## Root cause
The `process_request=self._process_request` was moved into a `dict[str, Any]` as part of the dual-stack refactor. Since `dict[str, Any]` accepts any value, the `type: ignore[arg-type]` became unused and mypy with `warn_unused_ignores` flagged it.

## Test plan
- [x] `mypy rxplus` passes: "Success: no issues found in 25 source files"

🤖 Generated with [Claude Code](https://claude.com/claude-code)